### PR TITLE
Update extension for Chrome MV3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,26 +1,32 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "version": "0.3.1",
-  "short_name": "WebMotion", 
-  "author": "Erik Linde", 
-    
+  "short_name": "WebMotion",
+  "author": "Erik Linde",
+
   "background": {
-    "scripts": ["jQuery.js", "domainUtils.js", "webMotionHelpers.js", "background.js"] 
+    "service_worker": "background.js"
   },
 
   "name": "WebMotion",
   "description": "Browse the web with your keyboard",
-  "permissions": [ 
-    "tabs", "storage", "http://*/", "https://*/" 
+  "permissions": [
+    "tabs",
+    "storage",
+    "scripting"
+  ],
+  "host_permissions": [
+    "http://*/*",
+    "https://*/*"
   ],
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",
     "128": "icon128.png"
     },
-  "browser_action": {
-    "default_icon": {                    
-      "19": "icon19.png",         
+  "action": {
+    "default_icon": {
+      "19": "icon19.png",
       "38": "icon38.png"
     },
     "default_title": "WebMotion",


### PR DESCRIPTION
## Summary
- migrate the extension manifest to version 3
- load helper scripts in the new service worker
- replace deprecated APIs in `background.js`
- use `chrome.scripting` for tab code execution

## Testing
- `git status --short`